### PR TITLE
Remove session dependency

### DIFF
--- a/nylas-strategy.js
+++ b/nylas-strategy.js
@@ -134,49 +134,34 @@ Strategy.prototype.authenticate = function(req, options) {
 		}
 	}
 
-	if (!req.session) { return this.error(new Error('OAuth authentication requires session support '))}
-
 	var self = this;
 
-	req.session.nylasCode = req.query.code;
-	if (req.session && req.session.nylasCode) {
-
+	if (req.query.code) {
 		function verified(err, user, info) {
 			if (err) {return self.error(err); }
 			if (!user) {return self.fail(info); }
 
 			info = info || {};
-			// req.session.nylasData.info = info;
 			self.success(user, info);
 		}
 
 		var params = this.tokenParams(options);
 		params.grant_type = 'authorization_code';
-		//params.redirect_uri = this._callbackURL;
-		// if (req.session.nylasData) {
-		// 	self.pass(req.session.nylasData.email, req.session.nylasData.info );
-		// } else {
-			this._oauth2.getOAuthAccessToken(req.session.nylasCode, params,
-				function(err, email, accessToken, params) {
-					if (err) {return self.error(new InternalOAuthError('failed to obtain access token', err)); }
+		this._oauth2.getOAuthAccessToken(req.query.code, params,
+			function(err, email, accessToken, params) {
+				if (err) {return self.error(new InternalOAuthError('failed to obtain access token', err)); }
 
-					//Additional nylas boject returned
-					var nylas = {};
-					nylas.provider = params.provider || null;
-					nylas.account_id = params.account_id || null;
-					nylas.token_type = params.token_type || null;
-					nylas.scopes = params.scopes || null;
-					nylas.email = email || null;
+				//Additional nylas boject returned
+				var nylas = {};
+				nylas.provider = params.provider || null;
+				nylas.account_id = params.account_id || null;
+				nylas.token_type = params.token_type || null;
+				nylas.scopes = params.scopes || null;
+				nylas.email = email || null;
 
-					// req.session.nylasData = {
-					// 	email: email,
-					// 	accessToken: accessToken
-					// }
-
-					self._verify(req, accessToken, nylas, verified);
-				}
-			);
-		// }
+				self._verify(req, accessToken, nylas, verified);
+			}
+		);
 	} else {
 		var params = this.authorizationParams(options);
 			params.response_type = 'code';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headstart/passport-nylas",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Fork of the Nylas authentication strategy for Passport using the OAuth 2.0 API.",
   "main": "./nylas-strategy.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headstart/passport-nylas",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Fork of the Nylas authentication strategy for Passport using the OAuth 2.0 API.",
   "main": "./nylas-strategy.js",
   "scripts": {


### PR DESCRIPTION
This library was still depending on sessions even though it wasn't really used for anything anymore as the entire auth flow was already performed in a stateless way.

By doing this update we can remove sessions from our api which is causing troubles when different company accounts are authenticating Nylas while sharing the same session. This problem is unlikely to happen to our clients but it's very likely to happen to us while logging in and out with different corporate accounts in a short amount of time from the same browser.

The entire auth flow was tested manually.