### PR TITLE
small refactoring to remove all the crazy mutations

### DIFF
--- a/nylas-strategy.js
+++ b/nylas-strategy.js
@@ -1,70 +1,84 @@
-var OAuth2Strategy = require('passport-oauth2')
-	, request = require('request')
-	, querystring = require('querystring')
-	, util = require('util')
-	, AuthorizationError = OAuth2Strategy.AuthorizationError
-	, InternalOAuthError = OAuth2Strategy.InternalOAuthError
-	;
+var OAuth2Strategy = require("passport-oauth2"),
+  request = require("request"),
+  querystring = require("querystring"),
+  util = require("util"),
+  AuthorizationError = OAuth2Strategy.AuthorizationError,
+  InternalOAuthError = OAuth2Strategy.InternalOAuthError;
+function OAuth2(
+  clientID,
+  clientSecret,
+  authorizationURL,
+  tokenURL,
+  customHeaders
+) {
+  this.clientID = clientID;
+  this.clientSecret = clientSecret;
+  this.authorizationURL =
+    authorizationURL || "https://api.nylas.com/oauth/authorize";
+  this.tokenURL = tokenURL || "https://api.nylas.com/oauth/token";
+  this._accessTokenName = "access_token";
+  this.customHeaders = customHeaders || {};
 
-function OAuth2(clientID, clientSecret, authorizationURL, tokenURL, customHeaders) {
-	this.clientID = clientID;
-	this.clientSecret = clientSecret;
-	this.authorizationURL = authorizationURL || "https://api.nylas.com/oauth/authorize";
-	this.tokenURL = tokenURL || "https://api.nylas.com/oauth/token";
-	this._accessTokenName = "access_token";
-	this.customHeaders = customHeaders || {};
-
-	return this;
+  return this;
 }
 
 // -- https://api.nylas.com/oauth/authorize
 OAuth2.prototype.getAuthorizeUrl = function({ loginHint, trial, ...rest }) {
   const params = rest;
 
-	if (!(this.clientID && this.clientSecret)) {
-		throw new Error("getAuthorizeUrl() cannot be called until you provide a client_id and client_secret");
-	}
-	if (!params.redirect_uri) {
-		throw new Error("getAuthorizeUrl() requires a redirect_uri");
+  if (!(this.clientID && this.clientSecret)) {
+    throw new Error(
+      "getAuthorizeUrl() cannot be called until you provide a client_id and client_secret"
+    );
+  }
+  if (!params.redirect_uri) {
+    throw new Error("getAuthorizeUrl() requires a redirect_uri");
   }
 
-  params.loginHint = loginHint || '';
-  params.trial =  trial || false;
+  params.loginHint = loginHint || "";
+  params.trial = trial || false;
   params.client_id = this.clientID;
 
-	return this.authorizationURL + "?" + querystring.stringify(params);
-}
+  return this.authorizationURL + "?" + querystring.stringify(params);
+};
 
 OAuth2.prototype.setAccessTokenName = function(name) {
-	this._accessTokenName = name;
-}
+  this._accessTokenName = name;
+};
 
 OAuth2.prototype.getOAuthAccessToken = function(code, grantType, callback) {
   const qs = {
     client_id: this.clientID,
-	  client_secret: this.clientSecret,
+    client_secret: this.clientSecret,
     grant_type: grantType,
-    code,
-  }
+    code
+  };
 
-	var _oauth = this;
+  var _oauth = this;
 
-	request({
-		method	: 'POST',
-		json: true,
-		url		: _oauth.tokenURL,
-		qs
-	}, function(error, response, body) {
-		if (error) { return callback(error, null) }
-		if (response.statusCode === 403) {return callback(403, null) }
+  request(
+    {
+      method: "POST",
+      json: true,
+      url: _oauth.tokenURL,
+      qs
+    },
+    function(error, response, body) {
+      if (error) {
+        return callback(error, null);
+      }
+      if (response.statusCode === 403) {
+        return callback(403, null);
+      }
 
-		var email_address = body["email_address"];
-		var access_token = body["access_token"];
-		//var provider = results["provider"];
-		//var account_id = results["account_id"]; -- both should be available in the results object
-		return callback(null, email_address, access_token, body);
-	});
-}
+      var email_address = body["email_address"];
+      var access_token = body["access_token"];
+      //var provider = results["provider"];
+      //var account_id = results["account_id"]; -- both should be available in the results object
+      return callback(null, email_address, access_token, body);
+    }
+  );
+};
 
 /**
 * Strategy constructor.
@@ -89,92 +103,109 @@ OAuth2.prototype.getOAuthAccessToken = function(code, grantType, callback) {
 * @api public
 */
 function Strategy(options, verify) {
-	options = options || {};
-	options.sessionKey = options.sessionKey || 'oauth2:nylas';
-	/*options.authorizationURL = options.authorizationURL || 'https://api.nylas.com/oauth/authorize';
+  options = options || {};
+  options.sessionKey = options.sessionKey || "oauth2:nylas";
+  /*options.authorizationURL = options.authorizationURL || 'https://api.nylas.com/oauth/authorize';
 	options.tokenURL = options.tokenURL || 'https://api.nylas.com/oauth/token';
 	options.clientID = options.clientID;
 	options.clientSecret = options.clientSecret;
 	options.scopes = options.scopes;
 	*/
 
-	if (!verify) {throw new TypeError('OAuth2Strategy requires a verify callback'); }
-	//if (!options.authorizationURL) {throw new TypeError('OAuth2Strategy requires an authorizationURL option'); }
-	//if (!options.tokenURL) {throw new TypeError('OAuth2Strategy requires a tokenURL option'); }
-	//if (!options.clientID) {throw new TypeError('OAuth2Strategy requires a clientID option'); }
+  if (!verify) {
+    throw new TypeError("OAuth2Strategy requires a verify callback");
+  }
+  //if (!options.authorizationURL) {throw new TypeError('OAuth2Strategy requires an authorizationURL option'); }
+  //if (!options.tokenURL) {throw new TypeError('OAuth2Strategy requires a tokenURL option'); }
+  //if (!options.clientID) {throw new TypeError('OAuth2Strategy requires a clientID option'); }
 
-	//this._options = options
-	this._verify = verify;
-	this._oauth2 = new OAuth2(options.clientID, options.clientSecret, options.authorizationURL, options.tokenURL, options.customHeaders);
-	this._scopes = options.scopes;
-	this._callbackURL = options.callbackURL;
+  //this._options = options
+  this._verify = verify;
+  this._oauth2 = new OAuth2(
+    options.clientID,
+    options.clientSecret,
+    options.authorizationURL,
+    options.tokenURL,
+    options.customHeaders
+  );
+  this._scopes = options.scopes;
+  this._callbackURL = options.callbackURL;
 
-
-	this.name = 'nylas';
+  this.name = "nylas";
 }
 
 util.inherits(Strategy, OAuth2Strategy);
 
-
 /**
-* Authenticating request using the OAuth 2.0 protocol
-* @param {Object} req
-* @api protected
-*/
+ * Authenticating request using the OAuth 2.0 protocol
+ * @param {Object} req
+ * @api protected
+ */
 
 Strategy.prototype.authenticate = function(req, options = {}) {
-	if (req.query && req.query.error) {
-		if (req.query.error == 'access_denied') {
-			return this.fail({ message: req.query.error_description});
-		} else {
-			return this.error(new AuthorizationError(req.query.error_description, req.query.error, req.query.error_uri));
-		}
-	}
+  if (req.query && req.query.error) {
+    if (req.query.error == "access_denied") {
+      return this.fail({ message: req.query.error_description });
+    } else {
+      return this.error(
+        new AuthorizationError(
+          req.query.error_description,
+          req.query.error,
+          req.query.error_uri
+        )
+      );
+    }
+  }
 
-	var self = this;
+  var self = this;
 
-	if (req.query.code) {
-		function verified(err, user, info) {
-			if (err) {
+  if (req.query.code) {
+    function verified(err, user, info) {
+      if (err) {
         return self.error(err);
       }
 
-			if (!user) {
+      if (!user) {
         return self.fail(info);
       }
 
-			info = info || {};
-			self.success(user, info);
-		}
+      info = info || {};
+      self.success(user, info);
+    }
 
-		this._oauth2.getOAuthAccessToken(req.query.code, 'authorization_code', function(err, email, accessToken, body) {
-				if (err) {
-          return self.error(new InternalOAuthError('failed to obtain access token', err));
+    this._oauth2.getOAuthAccessToken(
+      req.query.code,
+      "authorization_code",
+      function(err, email, accessToken, body) {
+        if (err) {
+          return self.error(
+            new InternalOAuthError("failed to obtain access token", err)
+          );
         }
 
-				//Additional nylas boject returned
-				const nylas = {};
-				nylas.provider = body.provider || null;
-				nylas.account_id = body.account_id || null;
-				nylas.token_type = body.token_type || null;
-				nylas.scopes = body.scopes || null;
-				nylas.email = email || null;
+        //Additional nylas boject returned
+        const nylas = {};
+        nylas.provider = body.provider || null;
+        nylas.account_id = body.account_id || null;
+        nylas.token_type = body.token_type || null;
+        nylas.scopes = body.scopes || null;
+        nylas.email = email || null;
 
-				self._verify(req, accessToken, nylas, verified);
-			}
-		);
-	} else {
-		const location = this._oauth2.getAuthorizeUrl({
-      response_type: 'code',
+        self._verify(req, accessToken, nylas, verified);
+      }
+    );
+  } else {
+    const location = this._oauth2.getAuthorizeUrl({
+      response_type: "code",
       redirect_uri: this._callbackURL,
       loginHint: req.query.login_hint,
-      scopes: this._scopes || 'email.read_only',
-			state: req.query.state || options.state,
-			trial: options.trial,
+      scopes: this._scopes || "email.read_only",
+      state: req.query.state || options.state,
+      trial: options.trial
     });
 
-		this.redirect(location);
-	}
+    this.redirect(location);
+  }
 };
 
 /* Authorize URL = "/oauth/authorize?client_id=" +
@@ -185,23 +216,22 @@ Strategy.prototype.authenticate = function(req, options = {}) {
 	"&redirect_uri=" + options.redirectURI;
 */
 
-
 /*
-* Override OAuth authorizeParams method to allow passing additional parms
-* per "pre-fill" Nylas feature
-* Return extra parameters to be included in the authorization request.
-*/
+ * Override OAuth authorizeParams method to allow passing additional parms
+ * per "pre-fill" Nylas feature
+ * Return extra parameters to be included in the authorization request.
+ */
 Strategy.prototype.authorizationParams = function(options) {
-	return options;
+  return options;
 };
 
 /*
-* Override OAuth authorizeParams method to allow passing additional parms
-* per "pre-fill" Nylas feature
-* Return extra parameters to be included in the token request.
-*/
+ * Override OAuth authorizeParams method to allow passing additional parms
+ * per "pre-fill" Nylas feature
+ * Return extra parameters to be included in the token request.
+ */
 Strategy.prototype.tokenParams = function(options) {
-	return options;
+  return options;
 };
 
 module.exports = Strategy;

--- a/nylas-strategy.js
+++ b/nylas-strategy.js
@@ -169,7 +169,8 @@ Strategy.prototype.authenticate = function(req, options = {}) {
       redirect_uri: this._callbackURL,
       loginHint: req.query.login_hint,
       scopes: this._scopes || 'email.read_only',
-      state: options.state || req.query.state,
+			state: req.query.state || options.state,
+			trial: options.trial,
     });
 
 		this.redirect(location);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headstart/passport-nylas",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Fork of the Nylas authentication strategy for Passport using the OAuth 2.0 API.",
   "main": "./nylas-strategy.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headstart/passport-nylas",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Fork of the Nylas authentication strategy for Passport using the OAuth 2.0 API.",
   "main": "./nylas-strategy.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headstart/passport-nylas",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Fork of the Nylas authentication strategy for Passport using the OAuth 2.0 API.",
   "main": "./nylas-strategy.js",
   "scripts": {


### PR DESCRIPTION
This library was mutating the `options` object all over the place. `options` is a configuration object shared between different parts of the authentication chain and mutating it is certainly not a great idea, as it will change for all the code that has access to it, no matter where it is.

The bit that was causing trouble is [this](https://github.com/headstart-app/passport-nylas/compare/master...headstart-app:remove-options-mutations?expand=1#diff-154befb29a040047b1d591f68ce97084L174). The state containing the current `companyId` was added to the `options` object (here disguised as `params`) making it the default state for the following requests. If the next request had a new state, it was discarded because the mutated `options` object would already provide a state  [here](https://github.com/headstart-app/passport-nylas/compare/master...headstart-app:remove-options-mutations?expand=1#diff-154befb29a040047b1d591f68ce97084L172). But of course the state provided by `options.state` is the one from the previous request so the Nylas credentials were saved in the wrong company object (the one specified in the previous request). :fearful: 